### PR TITLE
Support icons in window rule configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Add a CFFI module to your Waybar config:
       // if this value is too large, it will be reduced
       "spacing": 1,
       // set minimum size of windows, in pixels, to draw icons for (default: 0, minimum: 0)
-      // if unset or 0, icons will only be drawn for windows that are the only one in their column
+      // if unset or 0, icons will only be drawn for tiled windows that are the only one in their column
       // if 1+, icons will be drawn for all windows where w >= icon-minimum-size and h >= icon-minimum-size
       // icons must be set in the "rules" section below for this to have any effect
       "icon-minimum-size": 0,
@@ -78,6 +78,7 @@ Add a CFFI module to your Waybar config:
       // rules are checked in the order they are defined - first match wins and checking stops
       // set "continue" to true to also check and apply subsequent rules even if this rule matches
       // if multiple rules with icons are applied, the first one will be used
+      // *icons are not drawn for floating windows by default*; set "icon-minimum-size" to enable (see above)
       "rules": [
         // .alacritty will be added to all windows with the App ID "Alacritty"
         //  will be drawn in windows that match

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Add a CFFI module to your Waybar config:
       // set spacing between windows/columns, in pixels (default: 1, minimum: 0)
       // if this value is too large, it will be reduced
       "spacing": 1,
+      // set minimum size of windows, in pixels, to draw icons for (default: 0, minimum: 0)
+      // if unset or 0, icons will only be drawn for windows that are the only one in their column
+      // if 1+, icons will be drawn for all windows where w >= icon-minimum-size and h >= icon-minimum-size
+      // icons must be set in the "rules" section below for this to have any effect
+      "icon-minimum-size": 0,
       // account for borders when calculating window sizes; see note below (default: 0, minimum: 0)
       "column-borders": 0, // border on .column
       "floating-borders": 0, // border on .floating
@@ -68,13 +73,21 @@ Add a CFFI module to your Waybar config:
       "on-tile-click": "FocusWindow", // (default: FocusWindow)
       "on-tile-middle-click": "CloseWindow", // (default: CloseWindow)
       "on-tile-right-click": "", // (default: none)
-      // add CSS classes to windows based on their App ID/Title (see `niri msg windows`)
+      // add CSS classes/icons to windows based on their App ID/Title (see `niri msg windows`)
+      // Go regular expression syntax is supported for app-id and title (see https://pkg.go.dev/regexp/syntax)
+      // rules are checked in the order they are defined - first match wins and checking stops
+      // set "continue" to true to also check and apply subsequent rules even if this rule matches
+      // if multiple rules with icons are applied, the first one will be used
       "rules": [
-        // Go regular expression syntax is supported (see https://pkg.go.dev/regexp/syntax)
         // .alacritty will be added to all windows with the App ID "Alacritty"
-        { "app-id": "Alacritty", "class": "alacritty" },
+        //  will be drawn in windows that match
+        { "app-id": "Alacritty", "class": "alacritty", "icon": "" },
+        // .firefox will be added to all windows with the App ID "firefox"
+        // subsequent rules are also checked and applied for firefox windows
+        { "app-id": "firefox", "class": "firefox", "continue": true },
         // .youtube-music will be added to all windows that have "YouTube Music" at the end of their title
-        { "title": "YouTube Music$", "class": "youtube-music" }
+        //  will be drawn in windows that match
+        { "title": "YouTube Music$", "class": "youtube-music", "icon": "" }
       ],
 
       // ======= text mode options =======

--- a/module/config.go
+++ b/module/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	FloatingPosition  FloatingPosition `json:"floating-position"`
 	MinimumSize       int              `json:"minimum-size"`
 	Spacing           int              `json:"spacing"`
+	IconMinSize       int              `json:"icon-minimum-size"`
 	ColumnBorders     int              `json:"column-borders"`
 	FloatingBorders   int              `json:"floating-borders"`
 	OnTileClick       string           `json:"on-tile-click"`

--- a/module/config.go
+++ b/module/config.go
@@ -96,6 +96,7 @@ type WindowRuleConfig struct {
 	AppId    string `json:"app-id"`
 	Title    string `json:"title"`
 	Class    string `json:"class"`
+	Icon     string `json:"icon"`
 	Continue bool   `json:"continue"`
 }
 
@@ -103,6 +104,7 @@ type WindowRule struct {
 	AppId    *regexp.Regexp
 	Title    *regexp.Regexp
 	Class    string
+	Icon     string
 	Continue bool
 }
 
@@ -129,6 +131,7 @@ func (w *WindowRules) UnmarshalJSON(data []byte) error {
 			}
 		}
 		s[idx].Class = rule.Class
+		s[idx].Icon = rule.Icon
 		s[idx].Continue = rule.Continue
 	}
 	*w = s

--- a/module/module.go
+++ b/module/module.go
@@ -480,7 +480,7 @@ func (i *Instance) applyWindowRules(windowBox *gtk.EventBox, window *niri.Window
 				lab, err := gtk.LabelNew(rule.Icon)
 				if err != nil {
 					log.Errorf("error creating label: %s", err)
-					return
+					continue
 				}
 				windowBox.Add(lab)
 				iconAdded = true

--- a/module/module.go
+++ b/module/module.go
@@ -149,6 +149,10 @@ func (i *Instance) ApplyConfig(key, value string) error {
 			log.Warnf("spacing must be at least 0, setting to 0")
 			i.config.Spacing = 0
 		}
+		if i.config.IconMinSize < 0 {
+			log.Warnf("icon-minimum-size must be at least 0, setting to 0")
+			i.config.IconMinSize = 0
+		}
 		log.Debugf("config: %#+v", i.config)
 	case "module_path", "actions":
 		// ignore
@@ -374,7 +378,7 @@ func (i *Instance) drawFloating(maxWidth int, maxHeight int, floating []*niri.Wi
 			style.RemoveClass("urgent")
 		}
 
-		i.applyWindowRules(windowBox, window, false)
+		i.applyWindowRules(windowBox, window, i.config.IconMinSize > 0)
 		if window.IsFocused {
 			windowBox.SetStateFlags(gtk.STATE_FLAG_ACTIVE, false)
 			hasFocused = true
@@ -410,7 +414,7 @@ func (i *Instance) drawFloating(maxWidth int, maxHeight int, floating []*niri.Wi
 		i.connectButtonPress(windowBox, window)
 		i.connectTooltip(windowBox, window)
 		i.connectHover(windowBox)
-		i.applyWindowRules(windowBox, window, false)
+		i.applyWindowRules(windowBox, window, i.config.IconMinSize > 0)
 	}
 
 	if hasFocused {
@@ -472,7 +476,9 @@ func (i *Instance) applyWindowRules(windowBox gtk.IWidget, window *niri.Window, 
 		if appIdMatched && titleMatched {
 			style.AddClass(rule.Class)
 
-			if rule.Icon != "" && !iconAdded && showIcon {
+			w, h := windowBox.ToWidget().GetSizeRequest()
+			meetsMinSizeReq := w >= i.config.IconMinSize && h >= i.config.IconMinSize
+			if rule.Icon != "" && !iconAdded && showIcon && meetsMinSizeReq {
 				lab, err := gtk.LabelNew(rule.Icon)
 				if err != nil {
 					log.Errorf("error creating label: %s", err)

--- a/module/module.go
+++ b/module/module.go
@@ -299,7 +299,7 @@ func (i *Instance) Update() {
 				i.connectButtonPress(windowBox, window)
 				i.connectTooltip(windowBox, window)
 				i.connectHover(windowBox)
-				i.applyWindowRules(windowBox, window, len(column) == 1)
+				i.applyWindowRules(windowBox, window, len(column) == 1 || i.config.IconMinSize > 0)
 
 				colBox.Add(windowBox)
 			}

--- a/module/module.go
+++ b/module/module.go
@@ -423,6 +423,13 @@ func (i *Instance) getFloatingLayout(window *niri.Window, scale float64, maxWidt
 
 func (i *Instance) applyWindowRules(windowBox gtk.IWidget, window *niri.Window) {
 	style, _ := windowBox.ToWidget().GetStyleContext()
+	iconAdded := false
+	if box, ok := windowBox.(*gtk.EventBox); ok {
+		box.GetChildren().Foreach(func(child any) {
+			child.(*gtk.Widget).Destroy()
+		})
+	}
+
 	for _, rule := range i.config.WindowRules {
 		appIdMatched := rule.AppId == nil
 		titleMatched := rule.Title == nil
@@ -436,7 +443,7 @@ func (i *Instance) applyWindowRules(windowBox gtk.IWidget, window *niri.Window) 
 			style.AddClass(rule.Class)
 
 			_, h := windowBox.ToWidget().GetSizeRequest()
-			if rule.Icon != "" && h > i.allocatedHeight/2 {
+			if !iconAdded && rule.Icon != "" && h > i.allocatedHeight/2 {
 				lab, err := gtk.LabelNew(rule.Icon)
 				if err != nil {
 					log.Errorf("error creating label: %s", err)
@@ -445,6 +452,7 @@ func (i *Instance) applyWindowRules(windowBox gtk.IWidget, window *niri.Window) 
 				box, ok := windowBox.(*gtk.EventBox)
 				if ok {
 					box.Add(lab)
+					iconAdded = true
 				}
 			}
 			if !rule.Continue {

--- a/module/module.go
+++ b/module/module.go
@@ -295,7 +295,7 @@ func (i *Instance) Update() {
 				i.connectButtonPress(windowBox, window)
 				i.connectTooltip(windowBox, window)
 				i.connectHover(windowBox)
-				i.applyWindowRules(windowBox, window)
+				i.applyWindowRules(windowBox, window, len(column) == 1)
 
 				colBox.Add(windowBox)
 			}
@@ -374,7 +374,7 @@ func (i *Instance) drawFloating(maxWidth int, maxHeight int, floating []*niri.Wi
 			style.RemoveClass("urgent")
 		}
 
-		i.applyWindowRules(windowBox, window)
+		i.applyWindowRules(windowBox, window, false)
 		if window.IsFocused {
 			windowBox.SetStateFlags(gtk.STATE_FLAG_ACTIVE, false)
 			hasFocused = true
@@ -410,7 +410,7 @@ func (i *Instance) drawFloating(maxWidth int, maxHeight int, floating []*niri.Wi
 		i.connectButtonPress(windowBox, window)
 		i.connectTooltip(windowBox, window)
 		i.connectHover(windowBox)
-		i.applyWindowRules(windowBox, window)
+		i.applyWindowRules(windowBox, window, false)
 	}
 
 	if hasFocused {
@@ -451,7 +451,7 @@ func (i *Instance) getFloatingLayout(window *niri.Window, scale float64, maxWidt
 	return x, y, w, h
 }
 
-func (i *Instance) applyWindowRules(windowBox gtk.IWidget, window *niri.Window) {
+func (i *Instance) applyWindowRules(windowBox gtk.IWidget, window *niri.Window, showIcon bool) {
 	style, _ := windowBox.ToWidget().GetStyleContext()
 	iconAdded := false
 	if box, ok := windowBox.(*gtk.EventBox); ok {
@@ -472,8 +472,7 @@ func (i *Instance) applyWindowRules(windowBox gtk.IWidget, window *niri.Window) 
 		if appIdMatched && titleMatched {
 			style.AddClass(rule.Class)
 
-			_, h := windowBox.ToWidget().GetSizeRequest()
-			if !iconAdded && rule.Icon != "" && h > i.allocatedHeight/2 {
+			if rule.Icon != "" && !iconAdded && showIcon {
 				lab, err := gtk.LabelNew(rule.Icon)
 				if err != nil {
 					log.Errorf("error creating label: %s", err)

--- a/module/module.go
+++ b/module/module.go
@@ -351,7 +351,7 @@ func (i *Instance) drawFloating(maxWidth int, maxHeight int, floating []*niri.Wi
 
 	existingWindows := make(map[string]struct{})
 	i.floatingFixed.GetChildren().Foreach(func(item any) {
-		windowBox := item.(*gtk.Widget)
+		windowBox := &gtk.EventBox{Bin: gtk.Bin{Container: gtk.Container{Widget: *item.(*gtk.Widget)}}}
 		id, _ := windowBox.GetName()
 		var window *niri.Window
 		for _, w := range floating {
@@ -455,14 +455,12 @@ func (i *Instance) getFloatingLayout(window *niri.Window, scale float64, maxWidt
 	return x, y, w, h
 }
 
-func (i *Instance) applyWindowRules(windowBox gtk.IWidget, window *niri.Window, showIcon bool) {
+func (i *Instance) applyWindowRules(windowBox *gtk.EventBox, window *niri.Window, showIcon bool) {
 	style, _ := windowBox.ToWidget().GetStyleContext()
 	iconAdded := false
-	if box, ok := windowBox.(*gtk.EventBox); ok {
-		box.GetChildren().Foreach(func(child any) {
-			child.(*gtk.Widget).Destroy()
-		})
-	}
+	windowBox.GetChildren().Foreach(func(child any) {
+		child.(*gtk.Widget).Destroy()
+	})
 
 	for _, rule := range i.config.WindowRules {
 		appIdMatched := rule.AppId == nil
@@ -484,11 +482,8 @@ func (i *Instance) applyWindowRules(windowBox gtk.IWidget, window *niri.Window, 
 					log.Errorf("error creating label: %s", err)
 					return
 				}
-				box, ok := windowBox.(*gtk.EventBox)
-				if ok {
-					box.Add(lab)
-					iconAdded = true
-				}
+				windowBox.Add(lab)
+				iconAdded = true
 			}
 			if !rule.Continue {
 				break

--- a/module/module.go
+++ b/module/module.go
@@ -434,6 +434,19 @@ func (i *Instance) applyWindowRules(windowBox gtk.IWidget, window *niri.Window) 
 		}
 		if appIdMatched && titleMatched {
 			style.AddClass(rule.Class)
+
+			_, h := windowBox.ToWidget().GetSizeRequest()
+			if rule.Icon != "" && h > i.allocatedHeight/2 {
+				lab, err := gtk.LabelNew(rule.Icon)
+				if err != nil {
+					log.Errorf("error creating label: %s", err)
+					return
+				}
+				box, ok := windowBox.(*gtk.EventBox)
+				if ok {
+					box.Add(lab)
+				}
+			}
 			if !rule.Continue {
 				break
 			}


### PR DESCRIPTION
This PR adds some icons to each columns in graphical mode. No icons are shown when there are multiple tiles in one column, as it would blow up the bar.
<img width="161" height="34" alt="niri_windows_with_icons" src="https://github.com/user-attachments/assets/74569a66-07bd-4f00-946e-ab24410c737f" />

To define the icons, an additional 'icon' field was added to the window rules like that:
<img width="616" height="60" alt="niri_windows_with_icons_rules" src="https://github.com/user-attachments/assets/59a71b33-cf65-41f3-a642-cb4fdcdd05cf" />

Feel free to adapt the code if needed as I'm not that fluent in Go or even reject the PR if you don't want this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Window rules can include an "icon" attribute; matching windows may display the specified icon when layout space permits.
  * New "icon-minimum-size" setting controls the minimum size required to show icons; icons are hidden by default for floating windows.

* **Bug Fixes**
  * Prevents duplicate icons by clearing previous window contents before reapplying rules.
  * Clamps negative icon-minimum-size values to 0 and only shows icons when there’s sufficient height.

* **Documentation**
  * Updated config and rules docs to describe icon usage, regex support, and evaluation order.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->